### PR TITLE
Use docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM java:8u40-jdk
+RUN apt update && apt install maven -y --force-yes 
+COPY . /app
+RUN cd /app/ && mvn package
+RUN java -version > /version
+
+CMD java -jar /app/target/java-deserialization-lab-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,5 @@ FROM java:8u40-jdk
 RUN apt update && apt install maven -y --force-yes 
 COPY . /app
 RUN cd /app/ && mvn package
-RUN java -version > /version
 
 CMD java -jar /app/target/java-deserialization-lab-1.0-SNAPSHOT-jar-with-dependencies.jar

--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ More dependencies can be added through Maven if you want to try some more gadget
 
 ## Running
 
-Open (recommended with Intellij Idea) and run the Java class in **src/main/java/com/deserialization/lab/Main.java**.  
+```
+docker build -t cve-2017-7525 .
+docker run -p 9091:9091 cve-2017-7525
 
-Then browse to **http://localhost:9091/api/**
+Then browse to http://localhost:9091/api/
+
+```
 
 ### Exposed APIs
 

--- a/src/main/java/com/deserialization/lab/route/RouteBuilderImpl.java
+++ b/src/main/java/com/deserialization/lab/route/RouteBuilderImpl.java
@@ -12,7 +12,7 @@ public class RouteBuilderImpl extends RouteBuilder
     @Override
     public void configure() throws Exception
     {
-        restConfiguration().component("spark-rest").scheme("http").host("localhost").port(9091).bindingMode(RestBindingMode.auto);
+        restConfiguration().component("spark-rest").scheme("http").port(9091).bindingMode(RestBindingMode.auto);
 
         rest("/api/")
                 .get("message").to("direct:getMessage")


### PR DESCRIPTION
Use docker because it is hard to find java 8 and get it running.

I didn't add a reference to _ docker.io/wurstbrot/cve-2017-7525_ because it might be usable even if the mirrors for maven in the image not available, anymore.
Maybe you want to build the image and put it under your own account and provide info.